### PR TITLE
Add TTL indexes for Javers collections

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,17 @@
             <artifactId>guava</artifactId>
             <version>33.4.8-jre</version>
         </dependency>
+        <!-- Mongock for database migrations -->
+        <dependency>
+            <groupId>io.mongock</groupId>
+            <artifactId>mongodb-springdata-v4-driver</artifactId>
+            <version>5.3.6</version>
+        </dependency>
+        <dependency>
+            <groupId>io.mongock</groupId>
+            <artifactId>mongock-springboot</artifactId>
+            <version>5.3.6</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/sorushi/invoice/management/audit/config/MongoTTLConfig.java
+++ b/src/main/java/com/sorushi/invoice/management/audit/config/MongoTTLConfig.java
@@ -1,0 +1,37 @@
+package com.sorushi.invoice.management.audit.config;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.index.Index;
+import org.springframework.data.mongodb.core.index.IndexOperations;
+
+@Configuration
+@RequiredArgsConstructor
+public class MongoTTLConfig {
+
+  private final MongoTemplate mongoTemplate;
+
+  @Value("${javers.ttl.commit-metadata-days:30}")
+  private int commitMetadataDays;
+
+  @Value("${javers.ttl.snapshot-days:30}")
+  private int snapshotDays;
+
+  @PostConstruct
+  public void ensureTTLIndexes() {
+    long commitSeconds = commitMetadataDays * 24L * 3600L;
+    long snapshotSeconds = snapshotDays * 24L * 3600L;
+
+    IndexOperations commitOps = mongoTemplate.indexOps("commit_metadata");
+    commitOps.ensureIndex(
+        new Index().on("commitDateInstant", Sort.Direction.ASC).expire(commitSeconds));
+
+    IndexOperations snapshotOps = mongoTemplate.indexOps("jv_snapshot");
+    snapshotOps.ensureIndex(
+        new Index().on("commitMetadata.commitDateInstant", Sort.Direction.ASC).expire(snapshotSeconds));
+  }
+}

--- a/src/main/java/com/sorushi/invoice/management/audit/migration/JaversTTLChangeUnit.java
+++ b/src/main/java/com/sorushi/invoice/management/audit/migration/JaversTTLChangeUnit.java
@@ -1,17 +1,18 @@
-package com.sorushi.invoice.management.audit.config;
+package com.sorushi.invoice.management.audit.migration;
 
-import jakarta.annotation.PostConstruct;
+import io.mongock.api.annotations.ChangeUnit;
+import io.mongock.api.annotations.Execution;
+import io.mongock.api.annotations.RollbackExecution;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.index.Index;
 import org.springframework.data.mongodb.core.index.IndexOperations;
 
-@Configuration
+@ChangeUnit(id = "javers-ttl-indexes", order = "001", author = "codex")
 @RequiredArgsConstructor
-public class MongoTTLConfig {
+public class JaversTTLChangeUnit {
 
   private final MongoTemplate mongoTemplate;
 
@@ -21,8 +22,8 @@ public class MongoTTLConfig {
   @Value("${javers.ttl.snapshot-days:30}")
   private int snapshotDays;
 
-  @PostConstruct
-  public void ensureTTLIndexes() {
+  @Execution
+  public void addTTLIndexes() {
     long commitSeconds = commitMetadataDays * 24L * 3600L;
     long snapshotSeconds = snapshotDays * 24L * 3600L;
 
@@ -33,5 +34,13 @@ public class MongoTTLConfig {
     IndexOperations snapshotOps = mongoTemplate.indexOps("jv_snapshot");
     snapshotOps.ensureIndex(
         new Index().on("commitMetadata.commitDateInstant", Sort.Direction.ASC).expire(snapshotSeconds));
+  }
+
+  @RollbackExecution
+  public void rollback() {
+    IndexOperations commitOps = mongoTemplate.indexOps("commit_metadata");
+    commitOps.dropIndex("commitDateInstant_1");
+    IndexOperations snapshotOps = mongoTemplate.indexOps("jv_snapshot");
+    snapshotOps.dropIndex("commitMetadata.commitDateInstant_1");
   }
 }

--- a/src/main/java/com/sorushi/invoice/management/audit/migration/MongockConfig.java
+++ b/src/main/java/com/sorushi/invoice/management/audit/migration/MongockConfig.java
@@ -1,0 +1,24 @@
+package com.sorushi.invoice.management.audit.migration;
+
+import io.mongock.driver.mongodb.springdata.v4.driver.SpringDataMongoV4Driver;
+import io.mongock.runner.springboot.MongockInitializingBeanRunner;
+import io.mongock.runner.standalone.MongockStandalone;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.core.MongoTemplate;
+
+@Configuration
+public class MongockConfig {
+
+  @Bean
+  public MongockInitializingBeanRunner mongockRunner(
+      ApplicationContext springContext, MongoTemplate mongoTemplate) {
+    var driver = SpringDataMongoV4Driver.withDefaultLock(mongoTemplate);
+    return MongockStandalone.builder()
+        .setDriver(driver)
+        .addMigrationScanPackage("com.sorushi.invoice.management.audit.migration")
+        .setSpringContext(springContext)
+        .buildInitializingBeanRunner();
+  }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -11,3 +11,6 @@ javers:
     database-name: audit
   auditing:
     enabled: true
+  ttl:
+    commit-metadata-days: 30
+    snapshot-days: 30

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,3 +11,7 @@ spring:
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.apache.kafka.common.serialization.StringSerializer
+javers:
+  ttl:
+    commit-metadata-days: 30
+    snapshot-days: 30


### PR DESCRIPTION
## Summary
- configure TTL indexes for `commit_metadata` and `jv_snapshot` collections
- expose TTL settings via `application.yml` and `application-dev.yml`

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_6856dec814688321b7d3ab7b6df9f107