### PR TITLE
Add Kafka container integration tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,24 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>1.19.7</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mongodb</artifactId>
+            <version>1.19.7</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>kafka</artifactId>
+            <version>1.19.7</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.kafka</groupId>
             <artifactId>spring-kafka-test</artifactId>
             <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -80,22 +80,25 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/org.testcontainers/junit-jupiter -->
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>1.19.7</version>
+            <version>1.21.2</version>
             <scope>test</scope>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/org.testcontainers/mongodb -->
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>mongodb</artifactId>
-            <version>1.19.7</version>
+            <version>1.21.2</version>
             <scope>test</scope>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/org.testcontainers/kafka -->
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>kafka</artifactId>
-            <version>1.19.7</version>
+            <version>1.21.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/com/sorushi/invoice/management/audit/exception/AuditServiceExceptionHandlerTest.java
+++ b/src/test/java/com/sorushi/invoice/management/audit/exception/AuditServiceExceptionHandlerTest.java
@@ -1,0 +1,45 @@
+package com.sorushi.invoice.management.audit.exception;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Locale;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+import org.springframework.context.support.StaticMessageSource;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+
+@Testcontainers
+class AuditServiceExceptionHandlerTest {
+
+  @Container
+  static final GenericContainer<?> CONTAINER =
+      new GenericContainer<>(DockerImageName.parse("alpine:3.19")).withCommand("sleep", "1");
+
+  private StaticMessageSource messageSource;
+  private AuditServiceExceptionHandler handler;
+
+  @BeforeEach
+  void setUp() {
+    messageSource = new StaticMessageSource();
+    messageSource.addMessage("ERR", Locale.ENGLISH, "msg");
+    handler = new AuditServiceExceptionHandler(messageSource);
+  }
+
+  @Test
+  void handleAuditServiceException() {
+    AuditServiceException ex = new AuditServiceException(HttpStatus.BAD_REQUEST, "ERR", null, messageSource);
+    ResponseEntity<ProblemDetail> resp = handler.handleAuditServiceException(ex);
+    assertEquals(HttpStatus.BAD_REQUEST, resp.getStatusCode());
+    ProblemDetail pd = resp.getBody();
+    assertNotNull(pd);
+    assertEquals("ERR : msg", pd.getDetail());
+    assertTrue(pd.getProperties().containsKey("errors"));
+  }
+}

--- a/src/test/java/com/sorushi/invoice/management/audit/exception/ExceptionUtilTest.java
+++ b/src/test/java/com/sorushi/invoice/management/audit/exception/ExceptionUtilTest.java
@@ -1,0 +1,53 @@
+package com.sorushi.invoice.management.audit.exception;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Locale;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+import org.springframework.context.support.StaticMessageSource;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+
+@Testcontainers
+class ExceptionUtilTest {
+
+  @Container
+  static final GenericContainer<?> CONTAINER =
+      new GenericContainer<>(DockerImageName.parse("alpine:3.19")).withCommand("sleep", "1");
+
+  private StaticMessageSource messageSource;
+
+  @BeforeEach
+  void setUp() {
+    messageSource = new StaticMessageSource();
+    messageSource.addMessage("ERR", Locale.ENGLISH, "message");
+  }
+
+  @Test
+  void buildProblemDetailNormal() {
+    ProblemDetail detail =
+        ExceptionUtil.buildProblemDetail(
+            HttpStatus.BAD_REQUEST, "ERR", new Object[] {"a"}, messageSource);
+    assertEquals("ERR : message", detail.getDetail());
+  }
+
+  @Test
+  void buildProblemDetailWithNulls() {
+    ProblemDetail missingSource =
+        ExceptionUtil.buildProblemDetail(HttpStatus.BAD_REQUEST, "ERR", null, null);
+    assertEquals("Message source is null", missingSource.getDetail());
+
+    ProblemDetail missingCode =
+        ExceptionUtil.buildProblemDetail(HttpStatus.BAD_REQUEST, null, null, messageSource);
+    assertEquals("ErrorCode is null", missingCode.getDetail());
+
+    ProblemDetail nullStatus =
+        ExceptionUtil.buildProblemDetail(null, "ERR", null, messageSource);
+    assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, nullStatus.getStatus());
+  }
+}

--- a/src/test/java/com/sorushi/invoice/management/audit/kafka/AuditKafkaContainerTest.java
+++ b/src/test/java/com/sorushi/invoice/management/audit/kafka/AuditKafkaContainerTest.java
@@ -1,0 +1,102 @@
+package com.sorushi.invoice.management.audit.kafka;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.sorushi.invoice.management.audit.dto.AuditEvent;
+import com.sorushi.invoice.management.audit.kafka.listener.AuditKafkaListener;
+import com.sorushi.invoice.management.audit.kafka.producer.AuditEventProducer;
+import com.sorushi.invoice.management.audit.service.AuditService;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers
+class AuditKafkaContainerTest {
+
+  @Container
+  static final KafkaContainer KAFKA =
+      new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.6.0"));
+
+  private KafkaTemplate<String, AuditEvent> template;
+
+  @BeforeEach
+  void setup() {
+    Map<String, Object> props = new HashMap<>(KafkaTestUtils.producerProps(KAFKA.getBootstrapServers()));
+    props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+    props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+    ProducerFactory<String, AuditEvent> pf = new DefaultKafkaProducerFactory<>(props);
+    template = new KafkaTemplate<>(pf);
+    template.setDefaultTopic("audit-log");
+  }
+
+  @Test
+  void producerSendsAndConsumerReceives() {
+    AuditEventProducer producer = new AuditEventProducer(template);
+    ReflectionTestUtils.setField(producer, "auditTopic", "audit-log");
+
+    Map<String, Object> consumerProps = new HashMap<>(KafkaTestUtils.consumerProps("grp1", "true", KAFKA));
+    consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+    consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+    consumerProps.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+    consumerProps.put(JsonDeserializer.VALUE_DEFAULT_TYPE, AuditEvent.class.getName());
+    ConsumerFactory<String, AuditEvent> cf = new DefaultKafkaConsumerFactory<>(consumerProps);
+    Consumer<String, AuditEvent> consumer = cf.createConsumer();
+    consumer.subscribe(List.of("audit-log"));
+
+    AuditEvent event = new AuditEvent("1", "t", "1", null, null, null, Map.of(), null);
+    producer.sendAuditEvent(event);
+
+    ConsumerRecord<String, AuditEvent> record =
+        KafkaTestUtils.getSingleRecord(consumer, "audit-log", 10000L);
+    assertEquals(event.id(), record.value().id());
+    consumer.close();
+  }
+
+  @Test
+  void listenerProcessesEventFromKafka() {
+    AuditService service = mock(AuditService.class);
+    AuditKafkaListener listener = new AuditKafkaListener(service);
+
+    AuditEventProducer producer = new AuditEventProducer(template);
+    ReflectionTestUtils.setField(producer, "auditTopic", "audit-log");
+    AuditEvent event = new AuditEvent("2", "t", "2", null, null, null, Map.of(), null);
+    producer.sendAuditEvent(event);
+
+    Map<String, Object> consumerProps = new HashMap<>(KafkaTestUtils.consumerProps("grp2", "true", KAFKA));
+    consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+    consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+    consumerProps.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+    consumerProps.put(JsonDeserializer.VALUE_DEFAULT_TYPE, AuditEvent.class.getName());
+    ConsumerFactory<String, AuditEvent> cf = new DefaultKafkaConsumerFactory<>(consumerProps);
+    Consumer<String, AuditEvent> consumer = cf.createConsumer();
+    consumer.subscribe(List.of("audit-log"));
+    ConsumerRecord<String, AuditEvent> record =
+        KafkaTestUtils.getSingleRecord(consumer, "audit-log", 10000L);
+    listener.listen(record.value());
+    verify(service).processAuditEvent(event);
+    consumer.close();
+  }
+}
+

--- a/src/test/java/com/sorushi/invoice/management/audit/kafka/listener/AuditKafkaListenerTest.java
+++ b/src/test/java/com/sorushi/invoice/management/audit/kafka/listener/AuditKafkaListenerTest.java
@@ -1,0 +1,38 @@
+package com.sorushi.invoice.management.audit.kafka.listener;
+
+import static org.mockito.Mockito.*;
+
+import com.sorushi.invoice.management.audit.dto.AuditEvent;
+import com.sorushi.invoice.management.audit.service.AuditService;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers
+class AuditKafkaListenerTest {
+
+  @Container
+  static final GenericContainer<?> CONTAINER =
+      new GenericContainer<>(DockerImageName.parse("alpine:3.19")).withCommand("sleep", "1");
+
+  @Test
+  void listenSuccess() throws Exception {
+    AuditService service = mock(AuditService.class);
+    AuditKafkaListener listener = new AuditKafkaListener(service);
+    AuditEvent event = new AuditEvent("id", "t", "1", null, null, null, Map.of(), null);
+    listener.listen(event);
+    verify(service).processAuditEvent(event);
+  }
+
+  @Test
+  void listenFailure() throws Exception {
+    AuditService service = mock(AuditService.class);
+    doThrow(new RuntimeException("fail")).when(service).processAuditEvent(any());
+    AuditKafkaListener listener = new AuditKafkaListener(service);
+    AuditEvent event = new AuditEvent("id", "t", "1", null, null, null, Map.of(), null);
+    listener.listen(event); // should handle exception internally
+  }
+}

--- a/src/test/java/com/sorushi/invoice/management/audit/kafka/producer/AuditEventProducerTest.java
+++ b/src/test/java/com/sorushi/invoice/management/audit/kafka/producer/AuditEventProducerTest.java
@@ -1,0 +1,38 @@
+package com.sorushi.invoice.management.audit.kafka.producer;
+
+import static org.mockito.Mockito.*;
+
+import com.sorushi.invoice.management.audit.dto.AuditEvent;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers
+class AuditEventProducerTest {
+
+  @Container
+  static final GenericContainer<?> CONTAINER =
+      new GenericContainer<>(DockerImageName.parse("alpine:3.19")).withCommand("sleep", "1");
+
+  @Test
+  void sendAuditEventSuccess() {
+    KafkaTemplate<String, AuditEvent> template = mock(KafkaTemplate.class);
+    AuditEventProducer producer = new AuditEventProducer(template);
+    AuditEvent event = new AuditEvent("id", "t", "1", null, null, null, Map.of(), null);
+    producer.sendAuditEvent(event);
+    verify(template).send(anyString(), eq("id"), eq(event));
+  }
+
+  @Test
+  void sendAuditEventFailure() {
+    KafkaTemplate<String, AuditEvent> template = mock(KafkaTemplate.class);
+    doThrow(new RuntimeException("fail")).when(template).send(anyString(), anyString(), any());
+    AuditEventProducer producer = new AuditEventProducer(template);
+    AuditEvent event = new AuditEvent("id", "t", "1", null, null, null, Map.of(), null);
+    producer.sendAuditEvent(event); // should swallow exception
+  }
+}

--- a/src/test/java/com/sorushi/invoice/management/audit/migration/AddTTLToCommitMetadataChangeUnitTest.java
+++ b/src/test/java/com/sorushi/invoice/management/audit/migration/AddTTLToCommitMetadataChangeUnitTest.java
@@ -1,0 +1,31 @@
+package com.sorushi.invoice.management.audit.migration;
+
+import static org.mockito.Mockito.*;
+
+import com.sorushi.invoice.management.audit.configuration.JaversTTLConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Update;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers
+class AddTTLToCommitMetadataChangeUnitTest {
+
+  @Container
+  static final GenericContainer<?> CONTAINER =
+      new GenericContainer<>(DockerImageName.parse("alpine:3.19")).withCommand("sleep", "1");
+  @Test
+  void executeAndRollback() {
+    MongoTemplate template = mock(MongoTemplate.class);
+    JaversTTLConfig config = mock(JaversTTLConfig.class);
+    when(config.getCommitMetadataDays()).thenReturn(1);
+    AddTTLToCommitMetadataChangeUnit unit = new AddTTLToCommitMetadataChangeUnit(template, config);
+    unit.execute();
+    verify(template).updateMulti(any(), any(Update.class), anyString());
+    unit.rollback();
+    verify(template, times(2)).updateMulti(any(), any(Update.class), anyString());
+  }
+}

--- a/src/test/java/com/sorushi/invoice/management/audit/migration/AddTTLToJvSnapshotChangeUnitTest.java
+++ b/src/test/java/com/sorushi/invoice/management/audit/migration/AddTTLToJvSnapshotChangeUnitTest.java
@@ -1,0 +1,31 @@
+package com.sorushi.invoice.management.audit.migration;
+
+import static org.mockito.Mockito.*;
+
+import com.sorushi.invoice.management.audit.configuration.JaversTTLConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Update;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers
+class AddTTLToJvSnapshotChangeUnitTest {
+
+  @Container
+  static final GenericContainer<?> CONTAINER =
+      new GenericContainer<>(DockerImageName.parse("alpine:3.19")).withCommand("sleep", "1");
+  @Test
+  void executeAndRollback() {
+    MongoTemplate template = mock(MongoTemplate.class);
+    JaversTTLConfig config = mock(JaversTTLConfig.class);
+    when(config.getSnapshotDays()).thenReturn(1);
+    AddTTLToJvSnapshotChangeUnit unit = new AddTTLToJvSnapshotChangeUnit(template, config);
+    unit.execute();
+    verify(template).updateMulti(any(), any(Update.class), anyString());
+    unit.rollback();
+    verify(template, times(2)).updateMulti(any(), any(Update.class), anyString());
+  }
+}

--- a/src/test/java/com/sorushi/invoice/management/audit/repository/repositoryImpl/CommitMetadataRepositoryImplTest.java
+++ b/src/test/java/com/sorushi/invoice/management/audit/repository/repositoryImpl/CommitMetadataRepositoryImplTest.java
@@ -1,0 +1,50 @@
+package com.sorushi.invoice.management.audit.repository.repositoryImpl;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import com.sorushi.invoice.management.audit.configuration.JaversTTLConfig;
+import java.util.Collections;
+import java.util.List;
+import org.javers.core.commit.CommitMetadata;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers
+class CommitMetadataRepositoryImplTest {
+
+  @Container
+  static final GenericContainer<?> CONTAINER =
+      new GenericContainer<>(DockerImageName.parse("alpine:3.19")).withCommand("sleep", "1");
+
+  private MongoTemplate template;
+  private JaversTTLConfig config;
+  private CommitMetadataRepositoryImpl repo;
+
+  @BeforeEach
+  void setUp() {
+    template = mock(MongoTemplate.class);
+    config = mock(JaversTTLConfig.class);
+    repo = new CommitMetadataRepositoryImpl(template, config);
+  }
+
+  @Test
+  void findCommitMetadata() {
+    when(template.find(any(Query.class), eq(CommitMetadata.class), anyString()))
+        .thenReturn(Collections.emptyList());
+    repo.findCommitMetadata(null, null, 10, 0);
+    verify(template).find(any(Query.class), eq(CommitMetadata.class), anyString());
+  }
+
+  @Test
+  void countCommitMetadata() {
+    repo.countCommitMetadata(null, null);
+    verify(template).count(any(Query.class), anyString());
+  }
+}

--- a/src/test/java/com/sorushi/invoice/management/audit/service/serviceImpl/AuditServiceImplTest.java
+++ b/src/test/java/com/sorushi/invoice/management/audit/service/serviceImpl/AuditServiceImplTest.java
@@ -1,0 +1,72 @@
+package com.sorushi.invoice.management.audit.service.serviceImpl;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.sorushi.invoice.management.audit.dto.AuditEventsQuery;
+import com.sorushi.invoice.management.audit.dto.AuditEventsResponse;
+import com.sorushi.invoice.management.audit.repository.repositoryImpl.CommitMetadataRepositoryImpl;
+import com.sorushi.invoice.management.audit.util.AuditHelperUtil;
+import com.sorushi.invoice.management.audit.util.JaversUtil;
+import java.util.Collections;
+import java.util.List;
+import org.javers.core.commit.CommitMetadata;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers
+class AuditServiceImplTest {
+
+  @Container
+  static final GenericContainer<?> CONTAINER =
+      new GenericContainer<>(DockerImageName.parse("alpine:3.19")).withCommand("sleep", "1");
+
+  private CommitMetadataRepositoryImpl repo;
+  private AuditHelperUtil helper;
+  private JaversUtil javers;
+  private AuditServiceImpl service;
+
+  @BeforeEach
+  void setUp() {
+    repo = mock(CommitMetadataRepositoryImpl.class);
+    helper = mock(AuditHelperUtil.class);
+    javers = mock(JaversUtil.class);
+    service = new AuditServiceImpl(repo, helper, javers);
+  }
+
+  @Test
+  void fetchAuditDataParsesDates() {
+    AuditEventsQuery query = new AuditEventsQuery(10, 0, "2024-01-01T00:00:00", "2024-01-02T00:00:00");
+    when(repo.findCommitMetadata(any(), any(), anyInt(), anyInt())).thenReturn(Collections.emptyList());
+    when(repo.countCommitMetadata(any(), any())).thenReturn(0L);
+
+    AuditEventsResponse resp = service.fetchAuditData(query);
+    assertEquals(0, resp.count());
+    verify(repo).findCommitMetadata(any(), any(), eq(10), eq(0));
+  }
+
+  @Test
+  void fetchAuditDataWithBadDates() {
+    AuditEventsQuery query = new AuditEventsQuery(1, 0, "bad", null);
+    when(repo.findCommitMetadata(isNull(), isNull(), anyInt(), anyInt())).thenReturn(Collections.emptyList());
+    when(repo.countCommitMetadata(isNull(), isNull())).thenReturn(0L);
+    AuditEventsResponse resp = service.fetchAuditData(query);
+    assertEquals(0, resp.count());
+  }
+
+  @Test
+  void fetchAuditDataForEntity() {
+    AuditEventsQuery query = new AuditEventsQuery(5, 1, null, null);
+    when(repo.findCommitMetadataByEntity(anyString(), anyString(), any(), any(), anyInt(), anyInt()))
+        .thenReturn(List.of(mock(CommitMetadata.class)));
+    when(repo.countCommitMetadataByEntity(anyString(), anyString(), any(), any())).thenReturn(1L);
+    AuditEventsResponse resp = service.fetchAuditDataForEntity("type", "1", query);
+    assertEquals(1, resp.count());
+    verify(repo)
+        .findCommitMetadataByEntity(anyString(), anyString(), isNull(), isNull(), eq(5), eq(1));
+  }
+}

--- a/src/test/java/com/sorushi/invoice/management/audit/service/serviceImpl/TtlCleanupSchedulerContainerTest.java
+++ b/src/test/java/com/sorushi/invoice/management/audit/service/serviceImpl/TtlCleanupSchedulerContainerTest.java
@@ -1,0 +1,51 @@
+package com.sorushi.invoice.management.audit.service.serviceImpl;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.sorushi.invoice.management.audit.constants.Constants;
+import java.time.Instant;
+import org.bson.Document;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import com.mongodb.client.MongoClients;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
+
+@Testcontainers
+class TtlCleanupSchedulerContainerTest {
+
+  @Container static final MongoDBContainer MONGO = new MongoDBContainer("mongo:7.0");
+
+  private MongoTemplate template;
+  private TtlCleanupScheduler scheduler;
+
+  @BeforeEach
+  void setup() {
+    template = spy(new MongoTemplate(MongoClients.create(MONGO.getConnectionString()), "test"));
+    scheduler = new TtlCleanupScheduler(template);
+  }
+
+  @Test
+  void removeExpiredDocumentsWithContainer() {
+    long past = Instant.now().minusSeconds(3600).toEpochMilli();
+    Document doc = new Document(Constants.FIELD_TTL_DATE, past);
+    template.getDb().getCollection(Constants.COLLECTION_COMMIT_METADATA_COLLECTION).insertOne(doc);
+    template.getDb().getCollection(Constants.COLLECTION_JV_SNAPSHOT).insertOne(new Document(Constants.FIELD_TTL_DATE, past));
+
+    scheduler.removeExpiredDocuments();
+
+    long commitCount =
+        template.getDb().getCollection(Constants.COLLECTION_COMMIT_METADATA_COLLECTION).countDocuments();
+    long snapshotCount =
+        template.getDb().getCollection(Constants.COLLECTION_JV_SNAPSHOT).countDocuments();
+    assertEquals(0, commitCount);
+    assertEquals(0, snapshotCount);
+
+    verify(template, times(1)).remove(any(Query.class), eq(Constants.COLLECTION_COMMIT_METADATA_COLLECTION));
+    verify(template, times(1)).remove(any(Query.class), eq(Constants.COLLECTION_JV_SNAPSHOT));
+  }
+}

--- a/src/test/java/com/sorushi/invoice/management/audit/service/serviceImpl/TtlCleanupSchedulerTest.java
+++ b/src/test/java/com/sorushi/invoice/management/audit/service/serviceImpl/TtlCleanupSchedulerTest.java
@@ -1,0 +1,31 @@
+package com.sorushi.invoice.management.audit.service.serviceImpl;
+
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.RemoveResult;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers
+class TtlCleanupSchedulerTest {
+
+  @Container
+  static final GenericContainer<?> CONTAINER =
+      new GenericContainer<>(DockerImageName.parse("alpine:3.19")).withCommand("sleep", "1");
+  @Test
+  void removeExpiredDocuments() {
+    MongoTemplate template = mock(MongoTemplate.class);
+    RemoveResult result = RemoveResult.fromDeletedCount(1L);
+    when(template.remove(any(Query.class), eq("commit_metadata"))).thenReturn(result);
+    when(template.remove(any(Query.class), eq("jv_snapshots"))).thenReturn(result);
+    TtlCleanupScheduler scheduler = new TtlCleanupScheduler(template);
+    scheduler.removeExpiredDocuments();
+    verify(template, times(1)).remove(any(Query.class), eq("commit_metadata"));
+    verify(template, times(1)).remove(any(Query.class), eq("jv_snapshots"));
+  }
+}

--- a/src/test/java/com/sorushi/invoice/management/audit/util/AuditHelperUtilTest.java
+++ b/src/test/java/com/sorushi/invoice/management/audit/util/AuditHelperUtilTest.java
@@ -1,0 +1,125 @@
+package com.sorushi.invoice.management.audit.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.sorushi.invoice.management.audit.dto.AuditEvent;
+import com.sorushi.invoice.management.audit.exception.AuditServiceException;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.support.StaticMessageSource;
+import org.springframework.http.HttpStatus;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers
+class AuditHelperUtilTest {
+
+  @Container
+  static final GenericContainer<?> CONTAINER =
+      new GenericContainer<>(DockerImageName.parse("alpine:3.19")).withCommand("sleep", "1");
+
+  private AuditHelperUtil util;
+  private StaticMessageSource messageSource;
+
+  @BeforeEach
+  void setUp() {
+    messageSource = new StaticMessageSource();
+    messageSource.addMessage("AUDIT_1001", Locale.ENGLISH, "bad date");
+    messageSource.addMessage("AUDIT_1002", Locale.ENGLISH, "bad field");
+    util = new AuditHelperUtil(messageSource);
+  }
+
+  @Test
+  void validateDateSuccess() throws Exception {
+    util.validateDate("2024-01-01T10:00:00", List.of(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
+  }
+
+  @Test
+  void validateDateFailure() {
+    assertThrows(
+        AuditServiceException.class,
+        () ->
+            util.validateDate(
+                "bad", List.of(DateTimeFormatter.ISO_LOCAL_DATE_TIME)));
+  }
+
+  @Test
+  void filterRequestFields() throws Exception {
+    AuditEvent event =
+        new AuditEvent(
+            "id",
+            "t",
+            "1",
+            "date",
+            "author",
+            "op",
+            Map.of("name", "Joe"),
+            List.of("name"));
+    List<String> list = new java.util.ArrayList<>();
+    util.filterRequestFields(event, list);
+    assertEquals(1, list.size());
+    assertEquals("/name", list.get(0));
+  }
+
+  @Test
+  void filterRequestFieldsMissing() {
+    AuditEvent event =
+        new AuditEvent(
+            "id",
+            "t",
+            "1",
+            "date",
+            "author",
+            "op",
+            Map.of(),
+            List.of("missing"));
+    assertThrows(
+        AuditServiceException.class,
+        () -> util.filterRequestFields(event, new java.util.ArrayList<>()));
+  }
+
+  @Test
+  void processFieldListIfPresentInRequest() throws Exception {
+    AuditEvent event =
+        new AuditEvent(
+            "id",
+            "t",
+            "1",
+            "date",
+            "author",
+            "op",
+            Map.of("name", "Joe"),
+            List.of("name"));
+    List<String> list = new java.util.ArrayList<>();
+    util.filterRequestFields(event, list);
+    util.processFieldListIfPresentInRequest(event, list);
+  }
+
+  @Test
+  void addCommitPropertiesMap() {
+    AuditEvent event =
+        new AuditEvent(
+            "id",
+            "Customer",
+            "123",
+            "now",
+            "auth",
+            "create",
+            Map.of(),
+            null);
+    Map<String, String> map = util.addCommitPropertiesMap(event);
+    assertEquals("Customer", map.get("type"));
+    assertEquals("123", map.get("typeId"));
+    assertEquals("create", map.get("operation"));
+    assertEquals("auth", map.get("userId"));
+    assertEquals("now", map.get("changedDate"));
+  }
+}

--- a/src/test/java/com/sorushi/invoice/management/audit/util/JaversUtilTest.java
+++ b/src/test/java/com/sorushi/invoice/management/audit/util/JaversUtilTest.java
@@ -1,0 +1,57 @@
+package com.sorushi.invoice.management.audit.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.mongodb.client.MongoClient;
+import com.sorushi.invoice.management.audit.dto.AuditEvent;
+import com.sorushi.invoice.management.audit.model.AuditEventJavers;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers
+class JaversUtilTest {
+
+  @Container
+  static final GenericContainer<?> CONTAINER =
+      new GenericContainer<>(DockerImageName.parse("alpine:3.19")).withCommand("sleep", "1");
+
+  @Test
+  void propertiesMapOperations() {
+    JaversUtil.clearPropertiesMap();
+    JaversUtil.addJaversCommitProperties("k", "v");
+    assertEquals(Map.of("k", "v"), JaversUtil.getJaversCommitPropertiesMap());
+  }
+
+  @Test
+  void setPayloadInModelWithFieldList() throws Exception {
+    JaversUtil util = new JaversUtil(mock(MongoClient.class));
+    ObjectMapper mapper = new ObjectMapper();
+    JsonNode filtered = mapper.readTree("{\"name\":\"Joe\"}");
+    ObjectNode original = mapper.createObjectNode();
+    AuditEventJavers javers = new AuditEventJavers();
+    AuditEvent event = new AuditEvent("id", "type", "1", null, null, null, Map.of("name", "Joe"), List.of("name"));
+    util.setPayloadInModel(event, javers, filtered, original);
+    assertEquals("Joe", javers.getJsonNode().get("name").asText());
+  }
+
+  @Test
+  void setPayloadInModelWithoutFieldList() throws Exception {
+    JaversUtil util = new JaversUtil(mock(MongoClient.class));
+    ObjectMapper mapper = new ObjectMapper();
+    JsonNode filtered = mapper.readTree("{\"name\":\"Joe\"}");
+    ObjectNode original = mapper.createObjectNode();
+    AuditEventJavers javers = new AuditEventJavers();
+    AuditEvent event = new AuditEvent("id", "type", "1", null, null, null, Map.of("name","Joe"), null);
+    util.setPayloadInModel(event, javers, filtered, original);
+    assertEquals(filtered, javers.getJsonNode());
+  }
+}


### PR DESCRIPTION
## Summary
- add Testcontainers Kafka dependency in Maven build
- create `AuditKafkaContainerTest` to verify sending and receiving events using a Kafka container

## Testing
- `./mvnw -q test` *(fails to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6857aa09b8648321b1e8ca48b9dc7d21