### PR TITLE
Refactor tests to share Testcontainer

### DIFF
--- a/src/test/java/com/sorushi/invoice/management/audit/BaseContainerTest.java
+++ b/src/test/java/com/sorushi/invoice/management/audit/BaseContainerTest.java
@@ -1,0 +1,16 @@
+package com.sorushi.invoice.management.audit;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+/** Base class that starts a lightweight container for all tests. */
+@Testcontainers
+public abstract class BaseContainerTest {
+
+  @Container
+  protected static final GenericContainer<?> ALPINE =
+      new GenericContainer<>(DockerImageName.parse("alpine:3.19"))
+          .withCommand("sleep", "1");
+}

--- a/src/test/java/com/sorushi/invoice/management/audit/exception/AuditServiceExceptionHandlerTest.java
+++ b/src/test/java/com/sorushi/invoice/management/audit/exception/AuditServiceExceptionHandlerTest.java
@@ -10,17 +10,9 @@ import org.springframework.context.support.StaticMessageSource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
+import com.sorushi.invoice.management.audit.BaseContainerTest;
 
-@Testcontainers
-class AuditServiceExceptionHandlerTest {
-
-  @Container
-  static final GenericContainer<?> CONTAINER =
-      new GenericContainer<>(DockerImageName.parse("alpine:3.19")).withCommand("sleep", "1");
+class AuditServiceExceptionHandlerTest extends BaseContainerTest {
 
   private StaticMessageSource messageSource;
   private AuditServiceExceptionHandler handler;

--- a/src/test/java/com/sorushi/invoice/management/audit/exception/ExceptionUtilTest.java
+++ b/src/test/java/com/sorushi/invoice/management/audit/exception/ExceptionUtilTest.java
@@ -8,17 +8,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.context.support.StaticMessageSource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
+import com.sorushi.invoice.management.audit.BaseContainerTest;
 
-@Testcontainers
-class ExceptionUtilTest {
-
-  @Container
-  static final GenericContainer<?> CONTAINER =
-      new GenericContainer<>(DockerImageName.parse("alpine:3.19")).withCommand("sleep", "1");
+class ExceptionUtilTest extends BaseContainerTest {
 
   private StaticMessageSource messageSource;
 

--- a/src/test/java/com/sorushi/invoice/management/audit/kafka/listener/AuditKafkaListenerTest.java
+++ b/src/test/java/com/sorushi/invoice/management/audit/kafka/listener/AuditKafkaListenerTest.java
@@ -6,17 +6,9 @@ import com.sorushi.invoice.management.audit.dto.AuditEvent;
 import com.sorushi.invoice.management.audit.service.AuditService;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
+import com.sorushi.invoice.management.audit.BaseContainerTest;
 
-@Testcontainers
-class AuditKafkaListenerTest {
-
-  @Container
-  static final GenericContainer<?> CONTAINER =
-      new GenericContainer<>(DockerImageName.parse("alpine:3.19")).withCommand("sleep", "1");
+class AuditKafkaListenerTest extends BaseContainerTest {
 
   @Test
   void listenSuccess() throws Exception {

--- a/src/test/java/com/sorushi/invoice/management/audit/kafka/producer/AuditEventProducerTest.java
+++ b/src/test/java/com/sorushi/invoice/management/audit/kafka/producer/AuditEventProducerTest.java
@@ -6,17 +6,9 @@ import com.sorushi.invoice.management.audit.dto.AuditEvent;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.kafka.core.KafkaTemplate;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
+import com.sorushi.invoice.management.audit.BaseContainerTest;
 
-@Testcontainers
-class AuditEventProducerTest {
-
-  @Container
-  static final GenericContainer<?> CONTAINER =
-      new GenericContainer<>(DockerImageName.parse("alpine:3.19")).withCommand("sleep", "1");
+class AuditEventProducerTest extends BaseContainerTest {
 
   @Test
   void sendAuditEventSuccess() {

--- a/src/test/java/com/sorushi/invoice/management/audit/migration/AddTTLToCommitMetadataChangeUnitTest.java
+++ b/src/test/java/com/sorushi/invoice/management/audit/migration/AddTTLToCommitMetadataChangeUnitTest.java
@@ -6,17 +6,9 @@ import com.sorushi.invoice.management.audit.configuration.JaversTTLConfig;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Update;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
+import com.sorushi.invoice.management.audit.BaseContainerTest;
 
-@Testcontainers
-class AddTTLToCommitMetadataChangeUnitTest {
-
-  @Container
-  static final GenericContainer<?> CONTAINER =
-      new GenericContainer<>(DockerImageName.parse("alpine:3.19")).withCommand("sleep", "1");
+class AddTTLToCommitMetadataChangeUnitTest extends BaseContainerTest {
 
   @Test
   void executeAndRollback() {

--- a/src/test/java/com/sorushi/invoice/management/audit/migration/AddTTLToJvSnapshotChangeUnitTest.java
+++ b/src/test/java/com/sorushi/invoice/management/audit/migration/AddTTLToJvSnapshotChangeUnitTest.java
@@ -6,17 +6,9 @@ import com.sorushi.invoice.management.audit.configuration.JaversTTLConfig;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Update;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
+import com.sorushi.invoice.management.audit.BaseContainerTest;
 
-@Testcontainers
-class AddTTLToJvSnapshotChangeUnitTest {
-
-  @Container
-  static final GenericContainer<?> CONTAINER =
-      new GenericContainer<>(DockerImageName.parse("alpine:3.19")).withCommand("sleep", "1");
+class AddTTLToJvSnapshotChangeUnitTest extends BaseContainerTest {
 
   @Test
   void executeAndRollback() {

--- a/src/test/java/com/sorushi/invoice/management/audit/repository/repositoryImpl/CommitMetadataRepositoryImplTest.java
+++ b/src/test/java/com/sorushi/invoice/management/audit/repository/repositoryImpl/CommitMetadataRepositoryImplTest.java
@@ -10,17 +10,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Query;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
+import com.sorushi.invoice.management.audit.BaseContainerTest;
 
-@Testcontainers
-class CommitMetadataRepositoryImplTest {
-
-  @Container
-  static final GenericContainer<?> CONTAINER =
-      new GenericContainer<>(DockerImageName.parse("alpine:3.19")).withCommand("sleep", "1");
+class CommitMetadataRepositoryImplTest extends BaseContainerTest {
 
   private MongoTemplate template;
   private JaversTTLConfig config;

--- a/src/test/java/com/sorushi/invoice/management/audit/service/serviceImpl/AuditServiceImplTest.java
+++ b/src/test/java/com/sorushi/invoice/management/audit/service/serviceImpl/AuditServiceImplTest.java
@@ -13,17 +13,9 @@ import java.util.List;
 import org.javers.core.commit.CommitMetadata;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
+import com.sorushi.invoice.management.audit.BaseContainerTest;
 
-@Testcontainers
-class AuditServiceImplTest {
-
-  @Container
-  static final GenericContainer<?> CONTAINER =
-      new GenericContainer<>(DockerImageName.parse("alpine:3.19")).withCommand("sleep", "1");
+class AuditServiceImplTest extends BaseContainerTest {
 
   private CommitMetadataRepositoryImpl repo;
   private AuditHelperUtil helper;

--- a/src/test/java/com/sorushi/invoice/management/audit/service/serviceImpl/TtlCleanupSchedulerTest.java
+++ b/src/test/java/com/sorushi/invoice/management/audit/service/serviceImpl/TtlCleanupSchedulerTest.java
@@ -6,17 +6,9 @@ import com.mongodb.client.result.DeleteResult;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Query;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
+import com.sorushi.invoice.management.audit.BaseContainerTest;
 
-@Testcontainers
-class TtlCleanupSchedulerTest {
-
-  @Container
-  static final GenericContainer<?> CONTAINER =
-      new GenericContainer<>(DockerImageName.parse("alpine:3.19")).withCommand("sleep", "1");
+class TtlCleanupSchedulerTest extends BaseContainerTest {
 
   @Test
   void removeExpiredDocuments() {

--- a/src/test/java/com/sorushi/invoice/management/audit/util/AuditHelperUtilTest.java
+++ b/src/test/java/com/sorushi/invoice/management/audit/util/AuditHelperUtilTest.java
@@ -12,17 +12,9 @@ import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.support.StaticMessageSource;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
+import com.sorushi.invoice.management.audit.BaseContainerTest;
 
-@Testcontainers
-class AuditHelperUtilTest {
-
-  @Container
-  static final GenericContainer<?> CONTAINER =
-      new GenericContainer<>(DockerImageName.parse("alpine:3.19")).withCommand("sleep", "1");
+class AuditHelperUtilTest extends BaseContainerTest {
 
   private AuditHelperUtil util;
   private StaticMessageSource messageSource;

--- a/src/test/java/com/sorushi/invoice/management/audit/util/JaversUtilTest.java
+++ b/src/test/java/com/sorushi/invoice/management/audit/util/JaversUtilTest.java
@@ -12,17 +12,9 @@ import com.sorushi.invoice.management.audit.model.AuditEventJavers;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
+import com.sorushi.invoice.management.audit.BaseContainerTest;
 
-@Testcontainers
-class JaversUtilTest {
-
-  @Container
-  static final GenericContainer<?> CONTAINER =
-      new GenericContainer<>(DockerImageName.parse("alpine:3.19")).withCommand("sleep", "1");
+class JaversUtilTest extends BaseContainerTest {
 
   @Test
   void propertiesMapOperations() {


### PR DESCRIPTION
## Summary
- add BaseContainerTest that provides a lightweight container
- refactor unit tests to extend the shared BaseContainerTest

## Testing
- `./mvnw -q test` *(fails: Failed to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6857b43e84b08321b4e364256f52cb33