### PR TITLE
Add user-based audit retrieval

### DIFF
--- a/src/main/java/com/sorushi/invoice/management/audit/constants/APIEndpoints.java
+++ b/src/main/java/com/sorushi/invoice/management/audit/constants/APIEndpoints.java
@@ -6,6 +6,7 @@ public class APIEndpoints {
   public static final String LOG_DATA = "/log";
   public static final String FETCH_AUDIT_DATA = "/audit";
   public static final String FETCH_AUDIT_DATA_BY_ENTITY = "/audit/{entityType}/{entityId}";
+  public static final String FETCH_AUDIT_DATA_BY_USER = "/audit/user/{userId}";
 
   private APIEndpoints() {}
 }

--- a/src/main/java/com/sorushi/invoice/management/audit/controller/AuditController.java
+++ b/src/main/java/com/sorushi/invoice/management/audit/controller/AuditController.java
@@ -101,4 +101,27 @@ public class AuditController {
     log.info("Fetched {} audit events for entity [{}:{}].", response.count(), entityType, entityId);
     return ResponseEntity.ok(response);
   }
+
+  @GetMapping(FETCH_AUDIT_DATA_BY_USER)
+  public ResponseEntity<AuditEventsResponse> fetchAuditDataByUser(
+      @PathVariable String userId,
+      @RequestParam(required = false) Integer limit,
+      @RequestParam(required = false) Integer skip,
+      @RequestParam(required = false) String startDate,
+      @RequestParam(required = false) String endDate) {
+
+    log.info(
+        "Received request to fetch audit data by user - userId: {}, limit: {}, skip: {}, startDate: {}, endDate: {}",
+        userId,
+        limit,
+        skip,
+        startDate,
+        endDate);
+
+    AuditEventsQuery query = new AuditEventsQuery(limit, skip, startDate, endDate);
+    AuditEventsResponse response = auditService.fetchAuditDataForUser(userId, query);
+
+    log.info("Fetched {} audit events for user {}.", response.count(), userId);
+    return ResponseEntity.ok(response);
+  }
 }

--- a/src/main/java/com/sorushi/invoice/management/audit/repository/CommitMetadataRepository.java
+++ b/src/main/java/com/sorushi/invoice/management/audit/repository/CommitMetadataRepository.java
@@ -16,4 +16,9 @@ public interface CommitMetadataRepository {
 
   long countCommitMetadataByEntity(
       String entityType, String entityId, Date startDate, Date endDate);
+
+  List<CommitMetadata> findCommitMetadataByUser(
+      String userId, Date startDate, Date endDate, int limit, int skip);
+
+  long countCommitMetadataByUser(String userId, Date startDate, Date endDate);
 }

--- a/src/main/java/com/sorushi/invoice/management/audit/repository/repositoryImpl/CommitMetadataRepositoryImpl.java
+++ b/src/main/java/com/sorushi/invoice/management/audit/repository/repositoryImpl/CommitMetadataRepositoryImpl.java
@@ -203,4 +203,66 @@ public class CommitMetadataRepositoryImpl implements CommitMetadataRepository {
     log.info("Counted {} commit metadata documents for [{}:{}]", count, entityType, entityId);
     return count;
   }
+
+  @Override
+  public List<CommitMetadata> findCommitMetadataByUser(
+      String userId, Date startDate, Date endDate, int limit, int skip) {
+
+    log.info(
+        "Fetching commit metadata for user {} with date range {} - {}, limit: {}, skip: {}",
+        userId,
+        startDate,
+        endDate,
+        limit,
+        skip);
+
+    Criteria criteria = Criteria.where(FIELD_PROPERTIES + DOT + USER_ID).is(userId);
+
+    if (startDate != null || endDate != null) {
+      Criteria dateCriteria = Criteria.where(FIELD_COMMIT_DATE);
+      if (startDate != null) {
+        dateCriteria = dateCriteria.gte(startDate);
+      }
+      if (endDate != null) {
+        dateCriteria = dateCriteria.lte(endDate);
+      }
+      criteria = new Criteria().andOperator(criteria, dateCriteria);
+    }
+
+    Query query = new Query(criteria);
+    if (skip > 0) query.skip(skip);
+    if (limit > 0) query.limit(limit);
+
+    List<CommitMetadata> commits =
+        mongoTemplate.find(query, CommitMetadata.class, COLLECTION_COMMIT_METADATA_COLLECTION);
+    log.info("Found {} commit metadata documents for user {}", commits.size(), userId);
+    return commits;
+  }
+
+  @Override
+  public long countCommitMetadataByUser(String userId, Date startDate, Date endDate) {
+    log.info(
+        "Counting commit metadata for user {} with date range {} - {}",
+        userId,
+        startDate,
+        endDate);
+
+    Criteria criteria = Criteria.where(FIELD_PROPERTIES + DOT + USER_ID).is(userId);
+
+    if (startDate != null || endDate != null) {
+      Criteria dateCriteria = Criteria.where(FIELD_COMMIT_DATE);
+      if (startDate != null) {
+        dateCriteria = dateCriteria.gte(startDate);
+      }
+      if (endDate != null) {
+        dateCriteria = dateCriteria.lte(endDate);
+      }
+      criteria = new Criteria().andOperator(criteria, dateCriteria);
+    }
+
+    Query query = new Query(criteria);
+    long count = mongoTemplate.count(query, COLLECTION_COMMIT_METADATA_COLLECTION);
+    log.info("Counted {} commit metadata documents for user {}", count, userId);
+    return count;
+  }
 }

--- a/src/main/java/com/sorushi/invoice/management/audit/service/AuditService.java
+++ b/src/main/java/com/sorushi/invoice/management/audit/service/AuditService.java
@@ -13,4 +13,6 @@ public interface AuditService {
 
   AuditEventsResponse fetchAuditDataForEntity(
       String entityType, String entityId, AuditEventsQuery query);
+
+  AuditEventsResponse fetchAuditDataForUser(String userId, AuditEventsQuery query);
 }

--- a/src/test/java/com/sorushi/invoice/management/audit/controller/AuditControllerTest.java
+++ b/src/test/java/com/sorushi/invoice/management/audit/controller/AuditControllerTest.java
@@ -82,4 +82,23 @@ class AuditControllerTest extends BaseContainerTest {
     assertEquals(response, resp.getBody());
     verify(service).fetchAuditDataForEntity(eq("type"), eq("1"), any(AuditEventsQuery.class));
   }
+
+  @Test
+  void fetchAuditDataByUserInvokesService() {
+    AuditEventsResponse response =
+        AuditEventsResponse.builder()
+            .result(Constants.RESPONSE_RESULT_SUCCESS)
+            .count(1L)
+            .records(Collections.emptyList())
+            .build();
+    when(service.fetchAuditDataForUser(eq("user"), any(AuditEventsQuery.class)))
+        .thenReturn(response);
+
+    ResponseEntity<AuditEventsResponse> resp =
+        controller.fetchAuditDataByUser("user", null, null, null, null);
+
+    assertEquals(HttpStatus.OK, resp.getStatusCode());
+    assertEquals(response, resp.getBody());
+    verify(service).fetchAuditDataForUser(eq("user"), any(AuditEventsQuery.class));
+  }
 }

--- a/src/test/java/com/sorushi/invoice/management/audit/repository/repositoryImpl/CommitMetadataRepositoryImplTest.java
+++ b/src/test/java/com/sorushi/invoice/management/audit/repository/repositoryImpl/CommitMetadataRepositoryImplTest.java
@@ -38,4 +38,18 @@ class CommitMetadataRepositoryImplTest extends BaseContainerTest {
     repo.countCommitMetadata(null, null);
     verify(template).count(any(Query.class), anyString());
   }
+
+  @Test
+  void findCommitMetadataByUser() {
+    when(template.find(any(Query.class), eq(CommitMetadata.class), anyString()))
+        .thenReturn(Collections.emptyList());
+    repo.findCommitMetadataByUser("u1", null, null, 5, 0);
+    verify(template).find(any(Query.class), eq(CommitMetadata.class), anyString());
+  }
+
+  @Test
+  void countCommitMetadataByUser() {
+    repo.countCommitMetadataByUser("u1", null, null);
+    verify(template).count(any(Query.class), anyString());
+  }
 }

--- a/src/test/java/com/sorushi/invoice/management/audit/service/serviceImpl/AuditServiceImplTest.java
+++ b/src/test/java/com/sorushi/invoice/management/audit/service/serviceImpl/AuditServiceImplTest.java
@@ -44,6 +44,19 @@ class AuditServiceImplTest extends BaseContainerTest {
   }
 
   @Test
+  void fetchAuditDataParsesOffsetDates() {
+    AuditEventsQuery query =
+        new AuditEventsQuery(1, 0, "2024-01-01T00:00:00Z", "2024-01-02T00:00:00Z");
+    when(repo.findCommitMetadata(any(), any(), anyInt(), anyInt()))
+        .thenReturn(Collections.emptyList());
+    when(repo.countCommitMetadata(any(), any())).thenReturn(0L);
+
+    AuditEventsResponse resp = service.fetchAuditData(query);
+    assertEquals(0, resp.count());
+    verify(repo).findCommitMetadata(any(), any(), eq(1), eq(0));
+  }
+
+  @Test
   void fetchAuditDataWithBadDates() {
     AuditEventsQuery query = new AuditEventsQuery(1, 0, "bad", null);
     when(repo.findCommitMetadata(isNull(), isNull(), anyInt(), anyInt()))
@@ -64,5 +77,19 @@ class AuditServiceImplTest extends BaseContainerTest {
     assertEquals(1, resp.count());
     verify(repo)
         .findCommitMetadataByEntity(anyString(), anyString(), isNull(), isNull(), eq(5), eq(1));
+  }
+
+  @Test
+  void fetchAuditDataForUser() {
+    AuditEventsQuery query = new AuditEventsQuery(2, 0, null, null);
+    when(repo.findCommitMetadataByUser(anyString(), any(), any(), anyInt(), anyInt()))
+        .thenReturn(List.of(mock(CommitMetadata.class)));
+    when(repo.countCommitMetadataByUser(anyString(), any(), any())).thenReturn(1L);
+
+    AuditEventsResponse resp = service.fetchAuditDataForUser("user", query);
+
+    assertEquals(1, resp.count());
+    verify(repo)
+        .findCommitMetadataByUser(eq("user"), isNull(), isNull(), eq(2), eq(0));
   }
 }


### PR DESCRIPTION
## Summary
- expose new `/audit/user/{userId}` endpoint
- support fetching audit records by user in service and repository
- enhance date parsing in `AuditServiceImpl`
- add unit tests for new functionality

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_6857d69c97dc8321bf9a9d336a016b84