### PR TITLE
Add entity history API

### DIFF
--- a/src/main/java/com/sorushi/invoice/management/audit/constants/APIEndpoints.java
+++ b/src/main/java/com/sorushi/invoice/management/audit/constants/APIEndpoints.java
@@ -7,6 +7,7 @@ public class APIEndpoints {
   public static final String FETCH_AUDIT_DATA = "/audit";
   public static final String FETCH_AUDIT_DATA_BY_ENTITY = "/audit/{entityType}/{entityId}";
   public static final String FETCH_AUDIT_DATA_BY_USER = "/audit/user/{userId}";
+  public static final String FETCH_ENTITY_HISTORY = "/audit/history/{entityType}/{entityId}";
 
   private APIEndpoints() {}
 }

--- a/src/main/java/com/sorushi/invoice/management/audit/controller/AuditController.java
+++ b/src/main/java/com/sorushi/invoice/management/audit/controller/AuditController.java
@@ -7,6 +7,7 @@ import com.sorushi.invoice.management.audit.dto.AuditEvent;
 import com.sorushi.invoice.management.audit.dto.AuditEventLoggedResponse;
 import com.sorushi.invoice.management.audit.dto.AuditEventsQuery;
 import com.sorushi.invoice.management.audit.dto.AuditEventsResponse;
+import com.sorushi.invoice.management.audit.dto.EntityHistoryResponse;
 import com.sorushi.invoice.management.audit.exception.AuditServiceException;
 import com.sorushi.invoice.management.audit.kafka.producer.AuditEventProducer;
 import com.sorushi.invoice.management.audit.service.serviceImpl.AuditServiceImpl;
@@ -122,6 +123,16 @@ public class AuditController {
     AuditEventsResponse response = auditService.fetchAuditDataForUser(userId, query);
 
     log.info("Fetched {} audit events for user {}.", response.count(), userId);
+    return ResponseEntity.ok(response);
+  }
+
+  @GetMapping(FETCH_ENTITY_HISTORY)
+  public ResponseEntity<EntityHistoryResponse> fetchEntityHistory(
+      @PathVariable String entityType, @PathVariable String entityId) {
+    log.info(
+        "Received request to fetch history for entityType: {}, entityId: {}", entityType, entityId);
+    EntityHistoryResponse response = auditService.fetchEntityHistory(entityType, entityId);
+    log.info("Fetched {} history records for entity [{}:{}]", response.count(), entityType, entityId);
     return ResponseEntity.ok(response);
   }
 }

--- a/src/main/java/com/sorushi/invoice/management/audit/dto/EntityHistoryRecord.java
+++ b/src/main/java/com/sorushi/invoice/management/audit/dto/EntityHistoryRecord.java
@@ -1,0 +1,14 @@
+package com.sorushi.invoice.management.audit.dto;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.Date;
+import lombok.Builder;
+
+@Builder
+public record EntityHistoryRecord(
+    String author,
+    String operation,
+    String changedDate,
+    Date commitDate,
+    JsonNode oldValue,
+    JsonNode newValue) {}

--- a/src/main/java/com/sorushi/invoice/management/audit/dto/EntityHistoryResponse.java
+++ b/src/main/java/com/sorushi/invoice/management/audit/dto/EntityHistoryResponse.java
@@ -1,0 +1,10 @@
+package com.sorushi.invoice.management.audit.dto;
+
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record EntityHistoryResponse(
+    String result,
+    Long count,
+    List<EntityHistoryRecord> records) {}

--- a/src/main/java/com/sorushi/invoice/management/audit/service/AuditService.java
+++ b/src/main/java/com/sorushi/invoice/management/audit/service/AuditService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.sorushi.invoice.management.audit.dto.AuditEvent;
 import com.sorushi.invoice.management.audit.dto.AuditEventsQuery;
 import com.sorushi.invoice.management.audit.dto.AuditEventsResponse;
+import com.sorushi.invoice.management.audit.dto.EntityHistoryResponse;
 
 public interface AuditService {
 
@@ -15,4 +16,6 @@ public interface AuditService {
       String entityType, String entityId, AuditEventsQuery query);
 
   AuditEventsResponse fetchAuditDataForUser(String userId, AuditEventsQuery query);
+
+  EntityHistoryResponse fetchEntityHistory(String entityType, String entityId);
 }

--- a/src/main/java/com/sorushi/invoice/management/audit/service/serviceImpl/AuditServiceImpl.java
+++ b/src/main/java/com/sorushi/invoice/management/audit/service/serviceImpl/AuditServiceImpl.java
@@ -9,6 +9,8 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.sorushi.invoice.management.audit.dto.AuditEvent;
 import com.sorushi.invoice.management.audit.dto.AuditEventsQuery;
 import com.sorushi.invoice.management.audit.dto.AuditEventsResponse;
+import com.sorushi.invoice.management.audit.dto.EntityHistoryRecord;
+import com.sorushi.invoice.management.audit.dto.EntityHistoryResponse;
 import com.sorushi.invoice.management.audit.exception.AuditServiceException;
 import com.sorushi.invoice.management.audit.model.AuditEventJavers;
 import com.sorushi.invoice.management.audit.model.AuditEventView;
@@ -206,6 +208,38 @@ public class AuditServiceImpl implements AuditService {
         .result(RESPONSE_RESULT_SUCCESS)
         .count(count)
         .records(records)
+        .build();
+  }
+
+  @Override
+  public EntityHistoryResponse fetchEntityHistory(String entityType, String entityId) {
+    List<CommitMetadata> commits =
+        commitMetadataRepository.findCommitMetadataByEntity(entityType, entityId, null, null, 0, 0);
+    commits.sort(Comparator.comparing(CommitMetadata::getCommitDate));
+
+    List<EntityHistoryRecord> history = new ArrayList<>();
+    JsonNode previous = null;
+    for (CommitMetadata cm : commits) {
+      AuditEventJavers current =
+          javersUtil.getLastUpdatedVersion(entityType, entityId, cm.getId().getMajorId(), 0);
+      JsonNode currentNode = current != null ? current.getJsonNode() : null;
+      Map<String, String> props = cm.getProperties();
+      history.add(
+          EntityHistoryRecord.builder()
+              .author(cm.getAuthor())
+              .operation(props != null ? props.get(OPERATION) : null)
+              .changedDate(props != null ? props.get(CHANGED_DATE) : null)
+              .commitDate(cm.getCommitDate())
+              .oldValue(previous)
+              .newValue(currentNode)
+              .build());
+      previous = currentNode;
+    }
+
+    return EntityHistoryResponse.builder()
+        .result(RESPONSE_RESULT_SUCCESS)
+        .count((long) history.size())
+        .records(history)
         .build();
   }
 

--- a/src/test/java/com/sorushi/invoice/management/audit/controller/AuditControllerTest.java
+++ b/src/test/java/com/sorushi/invoice/management/audit/controller/AuditControllerTest.java
@@ -9,6 +9,7 @@ import com.sorushi.invoice.management.audit.dto.AuditEvent;
 import com.sorushi.invoice.management.audit.dto.AuditEventLoggedResponse;
 import com.sorushi.invoice.management.audit.dto.AuditEventsQuery;
 import com.sorushi.invoice.management.audit.dto.AuditEventsResponse;
+import com.sorushi.invoice.management.audit.dto.EntityHistoryResponse;
 import com.sorushi.invoice.management.audit.kafka.producer.AuditEventProducer;
 import com.sorushi.invoice.management.audit.service.serviceImpl.AuditServiceImpl;
 import java.util.Collections;
@@ -100,5 +101,22 @@ class AuditControllerTest extends BaseContainerTest {
     assertEquals(HttpStatus.OK, resp.getStatusCode());
     assertEquals(response, resp.getBody());
     verify(service).fetchAuditDataForUser(eq("user"), any(AuditEventsQuery.class));
+  }
+
+  @Test
+  void fetchEntityHistoryInvokesService() {
+    EntityHistoryResponse resp =
+        EntityHistoryResponse.builder()
+            .result(Constants.RESPONSE_RESULT_SUCCESS)
+            .count(0L)
+            .records(Collections.emptyList())
+            .build();
+    when(service.fetchEntityHistory("type", "1")).thenReturn(resp);
+
+    ResponseEntity<EntityHistoryResponse> response = controller.fetchEntityHistory("type", "1");
+
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertEquals(resp, response.getBody());
+    verify(service).fetchEntityHistory("type", "1");
   }
 }

--- a/src/test/java/com/sorushi/invoice/management/audit/service/serviceImpl/AuditServiceImplTest.java
+++ b/src/test/java/com/sorushi/invoice/management/audit/service/serviceImpl/AuditServiceImplTest.java
@@ -6,12 +6,16 @@ import static org.mockito.Mockito.*;
 import com.sorushi.invoice.management.audit.BaseContainerTest;
 import com.sorushi.invoice.management.audit.dto.AuditEventsQuery;
 import com.sorushi.invoice.management.audit.dto.AuditEventsResponse;
+import com.sorushi.invoice.management.audit.dto.EntityHistoryResponse;
+import com.sorushi.invoice.management.audit.model.AuditEventJavers;
+import com.sorushi.invoice.management.audit.constants.Constants;
 import com.sorushi.invoice.management.audit.repository.repositoryImpl.CommitMetadataRepositoryImpl;
 import com.sorushi.invoice.management.audit.util.AuditHelperUtil;
 import com.sorushi.invoice.management.audit.util.JaversUtil;
 import java.util.Collections;
 import java.util.List;
 import org.javers.core.commit.CommitMetadata;
+import org.javers.core.commit.CommitId;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -91,5 +95,36 @@ class AuditServiceImplTest extends BaseContainerTest {
     assertEquals(1, resp.count());
     verify(repo)
         .findCommitMetadataByUser(eq("user"), isNull(), isNull(), eq(2), eq(0));
+  }
+
+  @Test
+  void fetchEntityHistory() {
+    CommitMetadata cm1 = mock(CommitMetadata.class);
+    CommitMetadata cm2 = mock(CommitMetadata.class);
+    CommitId id1 = mock(CommitId.class);
+    CommitId id2 = mock(CommitId.class);
+    when(id1.getMajorId()).thenReturn(1L);
+    when(id2.getMajorId()).thenReturn(2L);
+    when(cm1.getId()).thenReturn(id1);
+    when(cm2.getId()).thenReturn(id2);
+    when(cm1.getCommitDate()).thenReturn(new java.util.Date(1));
+    when(cm2.getCommitDate()).thenReturn(new java.util.Date(2));
+    when(cm1.getAuthor()).thenReturn("a1");
+    when(cm2.getAuthor()).thenReturn("a2");
+    when(cm1.getProperties()).thenReturn(java.util.Map.of(Constants.OPERATION, "Create"));
+    when(cm2.getProperties()).thenReturn(java.util.Map.of(Constants.OPERATION, "Update"));
+
+    when(repo.findCommitMetadataByEntity(anyString(), anyString(), any(), any(), anyInt(), anyInt()))
+        .thenReturn(List.of(cm1, cm2));
+
+    AuditEventJavers j1 = new AuditEventJavers();
+    AuditEventJavers j2 = new AuditEventJavers();
+    when(javers.getLastUpdatedVersion("type", "1", 1L, 0)).thenReturn(j1);
+    when(javers.getLastUpdatedVersion("type", "1", 2L, 0)).thenReturn(j2);
+
+    EntityHistoryResponse resp = service.fetchEntityHistory("type", "1");
+    assertEquals(2, resp.count());
+    verify(repo)
+        .findCommitMetadataByEntity(eq("type"), eq("1"), isNull(), isNull(), eq(0), eq(0));
   }
 }


### PR DESCRIPTION
## Summary
- add `EntityHistoryRecord` and `EntityHistoryResponse` DTOs
- expose new endpoint `/audit/history/{entityType}/{entityId}` for entity history
- implement history retrieval in `AuditServiceImpl`
- declare method in `AuditService`
- update API endpoints constants
- test controller and service logic for new history API

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_6857dbc976008321a65379ef8e88cecb