### PR TITLE
Improve exception handling with error codes

### DIFF
--- a/src/main/java/com/sorushi/invoice/management/audit/exception/ErrorCodes.java
+++ b/src/main/java/com/sorushi/invoice/management/audit/exception/ErrorCodes.java
@@ -4,6 +4,11 @@ public class ErrorCodes {
 
   public static final String DATE_TIME_PARSING_ERROR = "AUDIT_1001";
   public static final String PARSE_FIELD_LIST_ERROR = "AUDIT_1002";
+  public static final String MISSING_DATABASE_NAME = "AUDIT_1003";
+  public static final String JAVERS_INIT_FAILED = "AUDIT_1004";
+  public static final String KAFKA_SEND_FAILED = "AUDIT_1005";
+  public static final String PROCESS_AUDIT_EVENT_FAILED = "AUDIT_1006";
+  public static final String COMMIT_METADATA_SAVE_FAILED = "AUDIT_1007";
 
   private ErrorCodes() {}
 }

--- a/src/main/java/com/sorushi/invoice/management/audit/kafka/listener/AuditKafkaListener.java
+++ b/src/main/java/com/sorushi/invoice/management/audit/kafka/listener/AuditKafkaListener.java
@@ -1,6 +1,7 @@
 package com.sorushi.invoice.management.audit.kafka.listener;
 
 import com.sorushi.invoice.management.audit.dto.AuditEvent;
+import com.sorushi.invoice.management.audit.exception.ErrorCodes;
 import com.sorushi.invoice.management.audit.service.AuditService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,7 +22,11 @@ public class AuditKafkaListener {
       auditService.processAuditEvent(auditEvent);
       log.info("Processed audit event with ID: {}", auditEvent.entityId());
     } catch (Exception e) {
-      log.error("Failed to process audit event with ID: {}", auditEvent.entityId(), e);
+      log.error(
+          "{}: Failed to process audit event with ID: {}",
+          ErrorCodes.PROCESS_AUDIT_EVENT_FAILED,
+          auditEvent.entityId(),
+          e);
     }
   }
 }

--- a/src/main/java/com/sorushi/invoice/management/audit/kafka/producer/AuditEventProducer.java
+++ b/src/main/java/com/sorushi/invoice/management/audit/kafka/producer/AuditEventProducer.java
@@ -1,6 +1,10 @@
 package com.sorushi.invoice.management.audit.kafka.producer;
 
 import com.sorushi.invoice.management.audit.dto.AuditEvent;
+import com.sorushi.invoice.management.audit.exception.AuditServiceException;
+import com.sorushi.invoice.management.audit.exception.ErrorCodes;
+import org.springframework.context.MessageSource;
+import org.springframework.http.HttpStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -13,6 +17,7 @@ import org.springframework.stereotype.Component;
 public class AuditEventProducer {
 
   private final KafkaTemplate<String, AuditEvent> kafkaTemplate;
+  private final MessageSource messageSource;
 
   @Value("${spring.kafka.topics.audit-topic}")
   private String auditTopic;
@@ -22,7 +27,12 @@ public class AuditEventProducer {
       kafkaTemplate.send(auditTopic, auditEvent.id(), auditEvent);
       log.info("Sent audit event with ID: {} to topic: {}", auditEvent.id(), auditTopic);
     } catch (Exception ex) {
-      log.error("Error while sending AuditEvent with ID: {}", auditEvent.id(), ex);
+      log.error("Failed to send AuditEvent with ID: {}", auditEvent.id(), ex);
+      throw new AuditServiceException(
+          HttpStatus.INTERNAL_SERVER_ERROR,
+          ErrorCodes.KAFKA_SEND_FAILED,
+          new Object[] {auditEvent.id()},
+          messageSource);
     }
   }
 }

--- a/src/main/resources/message_de.properties
+++ b/src/main/resources/message_de.properties
@@ -1,3 +1,8 @@
 # Error Code and Error Message
-AUDIT_1001=Exception occurred while parsing date {0} to format {1}.
-AUDIT_1002=Exception occurred while parsing field list.
+AUDIT_1001=Invalid date '{0}'. Allowed formats: {1}.
+AUDIT_1002=Request field list contains invalid path.
+AUDIT_1003=MongoDB database name is missing.
+AUDIT_1004=Could not initialize Javers repository for database '{0}'.
+AUDIT_1005=Failed to send audit event {0} to Kafka.
+AUDIT_1006=Failed to process audit event {0}.
+AUDIT_1007=Unable to save commit metadata {0}.

--- a/src/main/resources/message_en.properties
+++ b/src/main/resources/message_en.properties
@@ -1,3 +1,8 @@
 # Error Code and Error Message
-AUDIT_1001=Exception occurred while parsing date {0} to format {1}.
-AUDIT_1002=Exception occurred while parsing field list.
+AUDIT_1001=Invalid date '{0}'. Allowed formats: {1}.
+AUDIT_1002=Request field list contains invalid path.
+AUDIT_1003=MongoDB database name is missing.
+AUDIT_1004=Could not initialize Javers repository for database '{0}'.
+AUDIT_1005=Failed to send audit event {0} to Kafka.
+AUDIT_1006=Failed to process audit event {0}.
+AUDIT_1007=Unable to save commit metadata {0}.

--- a/src/main/resources/message_fr.properties
+++ b/src/main/resources/message_fr.properties
@@ -1,3 +1,8 @@
 # Error Code and Error Message
-AUDIT_1001=Exception occurred while parsing date {0} to format {1}.
-AUDIT_1002=Exception occurred while parsing field list.
+AUDIT_1001=Invalid date '{0}'. Allowed formats: {1}.
+AUDIT_1002=Request field list contains invalid path.
+AUDIT_1003=MongoDB database name is missing.
+AUDIT_1004=Could not initialize Javers repository for database '{0}'.
+AUDIT_1005=Failed to send audit event {0} to Kafka.
+AUDIT_1006=Failed to process audit event {0}.
+AUDIT_1007=Unable to save commit metadata {0}.

--- a/src/test/java/com/sorushi/invoice/management/audit/kafka/AuditKafkaContainerTest.java
+++ b/src/test/java/com/sorushi/invoice/management/audit/kafka/AuditKafkaContainerTest.java
@@ -8,6 +8,7 @@ import com.sorushi.invoice.management.audit.dto.AuditEvent;
 import com.sorushi.invoice.management.audit.kafka.listener.AuditKafkaListener;
 import com.sorushi.invoice.management.audit.kafka.producer.AuditEventProducer;
 import com.sorushi.invoice.management.audit.service.AuditService;
+import org.springframework.context.MessageSource;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -58,7 +59,7 @@ class AuditKafkaContainerTest {
 
   @Test
   void producerSendsAndConsumerReceives() {
-    AuditEventProducer producer = new AuditEventProducer(template);
+    AuditEventProducer producer = new AuditEventProducer(template, mock(MessageSource.class));
     ReflectionTestUtils.setField(producer, "auditTopic", TOPIC_PRODUCER);
 
     Map<String, Object> consumerProps =
@@ -85,7 +86,7 @@ class AuditKafkaContainerTest {
     AuditService service = mock(AuditService.class);
     AuditKafkaListener listener = new AuditKafkaListener(service);
 
-    AuditEventProducer producer = new AuditEventProducer(template);
+    AuditEventProducer producer = new AuditEventProducer(template, mock(MessageSource.class));
     ReflectionTestUtils.setField(producer, "auditTopic", TOPIC_LISTENER);
     AuditEvent event = new AuditEvent("2", "t", "2", null, null, null, Map.of(), null);
     producer.sendAuditEvent(event);

--- a/src/test/java/com/sorushi/invoice/management/audit/repository/repositoryImpl/CommitMetadataRepositoryImplTest.java
+++ b/src/test/java/com/sorushi/invoice/management/audit/repository/repositoryImpl/CommitMetadataRepositoryImplTest.java
@@ -9,6 +9,7 @@ import java.util.Collections;
 import org.javers.core.commit.CommitMetadata;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.context.MessageSource;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Query;
 
@@ -22,7 +23,7 @@ class CommitMetadataRepositoryImplTest extends BaseContainerTest {
   void setUp() {
     template = mock(MongoTemplate.class);
     config = mock(JaversTTLConfig.class);
-    repo = new CommitMetadataRepositoryImpl(template, config);
+    repo = new CommitMetadataRepositoryImpl(template, config, mock(org.springframework.context.MessageSource.class));
   }
 
   @Test

--- a/src/test/java/com/sorushi/invoice/management/audit/util/JaversUtilTest.java
+++ b/src/test/java/com/sorushi/invoice/management/audit/util/JaversUtilTest.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.mongodb.client.MongoClient;
+import org.springframework.context.MessageSource;
 import com.sorushi.invoice.management.audit.BaseContainerTest;
 import com.sorushi.invoice.management.audit.dto.AuditEvent;
 import com.sorushi.invoice.management.audit.model.AuditEventJavers;
@@ -25,7 +26,7 @@ class JaversUtilTest extends BaseContainerTest {
 
   @Test
   void setPayloadInModelWithFieldList() throws Exception {
-    JaversUtil util = new JaversUtil(mock(MongoClient.class));
+    JaversUtil util = new JaversUtil(mock(MongoClient.class), mock(MessageSource.class));
     ObjectMapper mapper = new ObjectMapper();
     JsonNode filtered = mapper.readTree("{\"name\":\"Joe\"}");
     ObjectNode original = mapper.createObjectNode();
@@ -38,7 +39,7 @@ class JaversUtilTest extends BaseContainerTest {
 
   @Test
   void setPayloadInModelWithoutFieldList() throws Exception {
-    JaversUtil util = new JaversUtil(mock(MongoClient.class));
+    JaversUtil util = new JaversUtil(mock(MongoClient.class), mock(MessageSource.class));
     ObjectMapper mapper = new ObjectMapper();
     JsonNode filtered = mapper.readTree("{\"name\":\"Joe\"}");
     ObjectNode original = mapper.createObjectNode();


### PR DESCRIPTION
## Summary
- refine audit error messages and add new codes
- include error codes in Kafka producer and repository failures
- log error code when Kafka listener fails
- update tests to match new constructors

## Testing
- `./mvnw -q test` *(fails: wget to Maven repository blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6857e18a0de88321a81750b67a5c1d74