### PR TITLE
Fix job skipping by removing pull_request_target conditions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,17 +5,15 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
-  pull_request_target:
-    types: [opened, reopened, synchronize, edited]
   schedule:
     - cron: '30 14 * * *'
     - cron: '32 16 * * *'
+    - cron: '30 0 * * *'
 
 jobs:
   build:
     name: Build & Package
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request_target'
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -41,7 +39,6 @@ jobs:
     name: Run Unit Tests
     runs-on: ubuntu-latest
     needs: build
-    if: github.event_name != 'pull_request_target'
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -74,7 +71,6 @@ jobs:
     name: CodeQL Security Analysis
     runs-on: ubuntu-latest
     needs: test
-    if: github.event_name != 'pull_request_target'
     permissions:
       security-events: write
       actions: read
@@ -115,3 +111,16 @@ jobs:
         uses: actions/dependency-review-action@v4
         with:
           comment-summary-in-pr: always
+
+  dependabot:
+    name: Run Dependabot
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Execute Dependabot Updates
+        uses: ahmadnassri/action-dependabot@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- remove the `pull_request_target` trigger
- allow build, test and CodeQL jobs to run for all events
- keep dependabot stage running daily at 6 AM IST

## Testing
- `sh ./mvnw -q test` *(fails to fetch Maven)*

------
https://chatgpt.com/codex/tasks/task_e_68584f6883e48321b7d1548cebb1b8bf