### PR TITLE
Add permissions for dependency review action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,9 @@ jobs:
     name: Dependency Review for PRs
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- grant pull request write permissions so Dependency Review can comment

## Testing
- `./mvnw -q test` *(fails: unable to fetch Maven dependencies due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685851c33b20832187e4dd19a270876d